### PR TITLE
Dimension removed fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ This mod is known to work with:
 
 * [Heart of the Machine](https://heart-of-the-machine.github.io/) 
   [(Github)](https://github.com/Heart-of-the-Machine/heart-of-the-machine)
+  [(Modrinth)](https://modrinth.com/mod/heart-of-the-machine)
   [(CurseForge)](https://www.curseforge.com/minecraft/mc-mods/heart-of-the-machine)
 * [Applied Energistics 2](https://ae-mod.info/) 
   [(Github)](https://github.com/AppliedEnergistics/Applied-Energistics-2)
   [(CurseForge)](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2)
   (Fabric Build)
+* Likely others.
+
+## Thanks to
+
+* `alcatrazEscapee` for providing the [dimension-removal fix](https://github.com/Mojang/DataFixerUpper/pull/55) in 
+  the first place.
+* `Kneelawk` for packaging the fix into a mixin-based fabric mod.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Dimension Update Fixer
-A simple mod that unyeets the Nether and End when a world is upgraded between Minecraft versions with dimension mods
-installed.
+A simple mod that unyeets the Nether and End when a world is loaded without a dimension or is upgraded between 
+Minecraft versions with dimension mods installed.
 
-## Non-Goals
-As of now, this mod is not intended to fix the issue where removing a dimension from a world deletes all other
-dimensions. This may be a goal in the future or Mojang might just fix it first.
+This mod does now fix the issue where removing a dimension from a world deletes all other dimensions.
+
+## Jank
+The way this mod fixes the dimension-removal issue is by mixing in and overriding the `decode` method in 
+`UnboundedMapCodec`. This is somewhat of a janky fix and may break other mods that expect a certain load order for 
+DFU classes or that also attempt to fix the dimension-removal issue in the same way.
 
 ## Known to Work With
 This mod is known to work with:

--- a/src/main/java/com/github/hotm/dimensionupdatefixer/mixin/UnboundedMapCodecMixin.java
+++ b/src/main/java/com/github/hotm/dimensionupdatefixer/mixin/UnboundedMapCodecMixin.java
@@ -1,0 +1,40 @@
+package com.github.hotm.dimensionupdatefixer.mixin;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.datafixers.util.Unit;
+import com.mojang.serialization.*;
+import com.mojang.serialization.codecs.BaseMapCodec;
+import com.mojang.serialization.codecs.UnboundedMapCodec;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.Map;
+
+@Mixin(UnboundedMapCodec.class)
+public abstract class UnboundedMapCodecMixin<K, V> implements BaseMapCodec<K, V>, Codec<Map<K, V>> {
+    @Override
+    public <T> DataResult<Map<K, V>> decode(DynamicOps<T> ops, MapLike<T> input) {
+        final ImmutableMap.Builder<K, V> read = ImmutableMap.builder();
+        final ImmutableList.Builder<Pair<T, T>> failed = ImmutableList.builder();
+
+        final DataResult<Unit> result = input.entries().reduce(
+                DataResult.success(Unit.INSTANCE, Lifecycle.stable()),
+                (r, pair) -> {
+                    final DataResult<K> k = keyCodec().parse(ops, pair.getFirst());
+                    final DataResult<V> v = elementCodec().parse(ops, pair.getSecond());
+
+                    final DataResult<Pair<K, V>> entry = k.apply2stable(Pair::of, v);
+                    entry.error().ifPresent(e -> failed.add(pair));
+                    entry.result().ifPresent(e -> read.put(e.getFirst(), e.getSecond()));
+                    return r.apply2stable((u, p) -> u, entry);
+                },
+                (r1, r2) -> r1.apply2stable((u1, u2) -> u1, r2)
+        );
+
+        final Map<K, V> elements = read.build();
+        final T errors = ops.createMap(failed.build().stream());
+
+        return result.map(unit -> elements).setPartial(elements).mapError(e -> e + " missed input: " + errors);
+    }
+}

--- a/src/main/resources/dimensionupdatefixer.mixins.json
+++ b/src/main/resources/dimensionupdatefixer.mixins.json
@@ -9,7 +9,8 @@
     "CompoundListAccessor",
     "ProductAccessor",
     "TagAccessor",
-    "TaggedChoiceAccessor"
+    "TaggedChoiceAccessor",
+    "UnboundedMapCodecMixin"
   ],
   "client": [
   ],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,9 +3,10 @@
   "id": "dimensionupdatefixer",
   "version": "${version}",
   "name": "Dimension Update Fixer",
-  "description": "A simple mod that unyeets the Nether and End when a world is upgraded between Minecraft versions with dimension mods installed",
+  "description": "A simple mod that unyeets the Nether and End when a world is loaded without a dimension or is upgraded between Minecraft versions with dimension mods installed",
   "authors": [
-    "Kneelawk"
+    "Kneelawk",
+    "alcatrazEscapee"
   ],
   "contact": {
     "homepage": "",


### PR DESCRIPTION
This adds the ability for DUF to fix prevent Minecraft worlds from losing dimensions when modded or custom dimensions are removed.